### PR TITLE
Update to v5.1.3-vmsetupfix

### DIFF
--- a/images/iso/autoinstall/nocloud-dhcp/user-data
+++ b/images/iso/autoinstall/nocloud-dhcp/user-data
@@ -54,7 +54,7 @@ autoinstall:
   late-commands:
     - rm -r /target/var/cache/apt
     - cp -r /cdrom/apt /target/var/cache/
-    - curtin in-target --target /target -- apt-get -yy install apt-transport-https iptables-persistent ipset libjansson4 libltdl7 liblzo2-2 libnet1 libyaml-0-2 nano ntp ntpdate snmp tcpdump net-tools libsnappy1v5 python3-dateutil
+    - curtin in-target --target /target -- apt-get -yy install apt-transport-https iptables-persistent ipset libjansson4 libltdl7 liblzo2-2 libnet1 libyaml-0-2 nano snmp tcpdump net-tools libsnappy1v5 python3-dateutil
     - |
       if [ -d /sys/firmware/efi ]; then
         apt-get install -y efibootmgr

--- a/images/iso/build_iso.sh
+++ b/images/iso/build_iso.sh
@@ -106,8 +106,8 @@ fi
   cd "$DIR"/working
   #[[ -d "$DIR/local_files/" ]] && cp "$DIR"/local_files/* .
   curl -L -o netsa-pkg.deb "${netsa_pkg_url}"
-  #curl -L -o "${ona_pkg_name}" "${ona_service_url}"
-  $sudo cp /obsrvbl/images/iso/ona-service_UbuntuNoble_amd64.deb /obsrvbl/images/iso/working/
+  curl -L -o "${ona_pkg_name}" "${ona_service_url}"
+  #$sudo cp /obsrvbl/images/iso/ona-service_UbuntuNoble_amd64.deb /obsrvbl/images/iso/working/
 
 
 
@@ -116,7 +116,7 @@ fi
 $sudo apt-get -y update
 # you can install packages here if you want
 
-PACKAGES="apt-transport-https iptables-persistent ipset libjansson4 libltdl7 liblzo2-2 libnet1 libyaml-0-2 nano ntp ntpdate snmp tcpdump net-tools libsnappy1v5 python3-dateutil"
+PACKAGES="apt-transport-https iptables-persistent ipset libjansson4 libltdl7 liblzo2-2 libnet1 libyaml-0-2 nano snmp tcpdump net-tools libsnappy1v5 python3-dateutil"
 $sudo apt-get -yyqq install --download-only ${PACKAGES}
 
 


### PR DESCRIPTION
This update brings in the `v5.1.3-vmsetupfix` changes to the mainline:

- The installer has been updated to fix the `Checksum Verification Failed` error that occurs during the deployment of new Virtual Machines. Existing deployments don't need that fix.